### PR TITLE
INCR-94: Support testing Python 3 in django-cas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
     - "mkdir geckodriver"
     - "tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver"
     - "export PATH=$PATH:$PWD/geckodriver"
-    - "pip install -r requirements/travis.txt"
+    - "pip install -r requirements/dev.txt"
+    - "pip install -r requirements/test.txt"
 script:
     - tox -e $TOXENV
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,5 @@ install:
     - "pip install -r requirements/test.txt"
 script:
     - tox -e $TOXENV
-deploy:
-  provider: pypi
-  user: edx
-  password:
-    secure: celTh9NJzWzxRMCo+uXDkmFIvQ1uvqBuDHwW/hVcN0gO9Ph0ubDRfXoH9LuVbtDJzMJ1r6O4DjFQU8Icd0bBDxUhIZ7+z/Alilz4ETCEsffLl6ZzRXvQdd+7pWhYavuyut52ImfFLhjsWuVYVmE+aybc1sPY6r7DTfbYz8E+aXM=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    condition: "$TOXENV = quality"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: python
+dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+python:
+    - 2.7
+    - 3.6
+    - 3.7
+env:
+    - TOXENV=django111
+    - TOXENV=django20
+    - TOXENV=django21
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=quality
+  exclude:
+    - python: 2.7
+      env: TOXENV=django20
+    - python: 2.7
+      env: TOXENV=django21
+  allow_failures:
+    - python: 3.6
+    - python: 3.7
+
+services:
+  - xvfb
+addons:
+    firefox: "52.0esr"
+install:
+    - "mkdir var"
+    - "wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz"
+    - "mkdir geckodriver"
+    - "tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver"
+    - "export PATH=$PATH:$PWD/geckodriver"
+    - "pip install -r requirements/travis.txt"
+script:
+    - tox -e $TOXENV
+deploy:
+  provider: pypi
+  user: edx
+  password:
+    secure: celTh9NJzWzxRMCo+uXDkmFIvQ1uvqBuDHwW/hVcN0gO9Ph0ubDRfXoH9LuVbtDJzMJ1r6O4DjFQU8Icd0bBDxUhIZ7+z/Alilz4ETCEsffLl6ZzRXvQdd+7pWhYavuyut52ImfFLhjsWuVYVmE+aybc1sPY6r7DTfbYz8E+aXM=
+  distributions: sdist bdist_wheel
+  on:
+    tags: true
+    condition: "$TOXENV = quality"
+notifications:
+  email: false

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ first==2.0.1              # via pip-tools
 pip-tools==1.10.1
 pluggy==0.5.2             # via tox
 py==1.4.34                # via tox
-six==1.11.0               # via pip-tools, tox
-tox-battery==0.5
-tox==2.9.1
+six==1.12.0               # via pip-tools, tox
+tox-battery==0.5.1
+tox==3.7.0
 virtualenv==15.1.0        # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,5 +11,5 @@ pluggy==0.5.2             # via tox
 py==1.4.34                # via tox
 six==1.12.0               # via pip-tools, tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.9.0
 virtualenv==15.1.0        # via tox

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ python_files = tests.py
 
 [testenv]
 deps =
-    django111: pip install Django>=1.11,<2.0
-    django20: pip install Django>=2.0,<2.1
-    django21: pip install Django>=2.1,<2.2
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-django{18,19,110,111}
+envlist = py{27,36,37}-django{111,20,21}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
@@ -9,10 +9,9 @@ python_files = tests.py
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<2.0
+    django111: pip install Django>=1.11,<2.0
+    django20: pip install Django>=2.0,<2.1
+    django21: pip install Django>=2.1,<2.2
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36,37}-django{111,20,21}
+envlist = py{27}-django{111},py{36,37}-django{111,20,21}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings


### PR DESCRIPTION
Fixes: https://openedx.atlassian.net/browse/INCR-94

Travis-CI needs to be enabled for this repo.  https://travis-ci.org/mitodl/django-cas